### PR TITLE
Free the limts so we can see how rebuild processes use node resources.

### DIFF
--- a/pkg/pod.go
+++ b/pkg/pod.go
@@ -136,11 +136,11 @@ func (pa PodArgs) GetPodObject() *core.Pod {
 					Resources: core.ResourceRequirements{
 						Limits: core.ResourceList{
 							core.ResourceCPU: resource.MustParse("1"),
-							core.ResourceMemory: resource.MustParse("1500Mi"),
+							core.ResourceMemory: resource.MustParse("10000Mi"),
 						},
 						Requests: core.ResourceList{
-							core.ResourceCPU: resource.MustParse("1"),
-							core.ResourceMemory: resource.MustParse("1500Mi"),
+							core.ResourceCPU: resource.MustParse("0.2"),
+							core.ResourceMemory: resource.MustParse("250Mi"),
 						},
 					},
 				},


### PR DESCRIPTION
Free the limts so we can see how rebuild processes use node resources.