### PR TITLE
Passing of AMQP URI configuration to Request Processing Pod

### DIFF
--- a/cmd/adaptation-service.go
+++ b/cmd/adaptation-service.go
@@ -50,6 +50,8 @@ var (
 	requestProcessingTimeout = os.Getenv("REQUEST_PROCESSING_TIMEOUT")
 	adaptationRequestQueueHostname = os.Getenv("ADAPTATION_REQUEST_QUEUE_HOSTNAME")
 	adaptationRequestQueuePort = os.Getenv("ADAPTATION_REQUEST_QUEUE_PORT")
+	archiveAdaptationRequestQueueHostname = os.Getenv("ARCHIVE_ADAPTATION_QUEUE_REQUEST_HOSTNAME")
+	archiveAdaptationRequestQueuePort = os.Getenv("ARCHIVE_ADAPTATION_REQUEST_QUEUE_PORT")
 )
 
 func main() {
@@ -130,6 +132,8 @@ func processMessage(d amqp.Delivery) (bool, error) {
 		RequestProcessingTimeout: requestProcessingTimeout,
 		AdaptationRequestQueueHostname: adaptationRequestQueueHostname,
 		AdaptationRequestQueuePort: adaptationRequestQueuePort,
+		ArchiveAdaptationRequestQueueHostname: archiveAdaptationRequestQueueHostname,
+		ArchiveAdaptationRequestQueuePort: archiveAdaptationRequestQueuePort,
 	}
 
 	err = podArgs.GetClient()

--- a/cmd/adaptation-service.go
+++ b/cmd/adaptation-service.go
@@ -89,7 +89,7 @@ func main() {
     fmt.Println("Connecting to ", amqpUrl.Host)
 
 	conn, err := amqp.Dial(amqpUrl.String())
-	failOnError(err, fmt.Sprint("Failed to connect to %s", amqpUrl.Host))
+	failOnError(err, fmt.Sprintf("Failed to connect to %s", amqpUrl.Host))
 	defer conn.Close()
 
 	ch, err := conn.Channel()

--- a/cmd/adaptation-service.go
+++ b/cmd/adaptation-service.go
@@ -48,6 +48,8 @@ var (
 	outputMount              = os.Getenv("OUTPUT_MOUNT")
 	requestProcessingImage   = os.Getenv("REQUEST_PROCESSING_IMAGE")
 	requestProcessingTimeout = os.Getenv("REQUEST_PROCESSING_TIMEOUT")
+	adaptationRequestQueueHostname = os.Getenv("ADAPTATION_REQUEST_QUEUE_HOSTNAME")
+	adaptationRequestQueuePort = os.Getenv("ADAPTATION_REQUEST_QUEUE_PORT")
 )
 
 func main() {
@@ -126,6 +128,8 @@ func processMessage(d amqp.Delivery) (bool, error) {
 		ReplyTo:                  d.ReplyTo,
 		RequestProcessingImage:   requestProcessingImage,
 		RequestProcessingTimeout: requestProcessingTimeout,
+		AdaptationRequestQueueHostname: adaptationRequestQueueHostname,
+		AdaptationRequestQueuePort: adaptationRequestQueuePort,
 	}
 
 	err = podArgs.GetClient()

--- a/cmd/adaptation-service.go
+++ b/cmd/adaptation-service.go
@@ -6,6 +6,8 @@ import (
 	"log"
 	"os"
 	"time"
+	
+	"net/url"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -43,7 +45,6 @@ var (
 	)
 
 	podNamespace             = os.Getenv("POD_NAMESPACE")
-	amqpURL                  = os.Getenv("AMQP_URL")
 	inputMount               = os.Getenv("INPUT_MOUNT")
 	outputMount              = os.Getenv("OUTPUT_MOUNT")
 	requestProcessingImage   = os.Getenv("REQUEST_PROCESSING_IMAGE")
@@ -54,15 +55,41 @@ var (
 	archiveAdaptationRequestQueuePort = os.Getenv("ARCHIVE_ADAPTATION_REQUEST_QUEUE_PORT")
 	transactionEventQueueHostname = os.Getenv("TRANSACTION_EVENT_QUEUE_HOSTNAME")
 	transactionEventQueuePort = os.Getenv("TRANSACTION_EVENT_QUEUE_PORT")
+	messagebrokeruser = os.Getenv("MESSAGE_BROKER_USER")
+	messagebrokerpassword = os.Getenv("MESSAGE_BROKER_PASSWORD")
+	
 )
 
 func main() {
-	if podNamespace == "" || amqpURL == "" || inputMount == "" || outputMount == "" {
-		log.Fatalf("init failed: POD_NAMESPACE, AMQP_URL, INPUT_MOUNT or OUTPUT_MOUNT environment variables not set")
+	if podNamespace == "" || inputMount == "" || outputMount == "" {
+		log.Fatalf("init failed: POD_NAMESPACE, INPUT_MOUNT or OUTPUT_MOUNT environment variables not set")
 	}
+	
+	if adaptationRequestQueueHostname == "" || archiveAdaptationRequestQueueHostname == "" || transactionEventQueueHostname == "" {
+	    log.Fatalf("init failed: ADAPTATION_REQUEST_QUEUE_HOSTNAME, ARCHIVE_ADAPTATION_QUEUE_REQUEST_HOSTNAME or TRANSACTION_EVENT_QUEUE_HOSTNAME environment variables not set")
+	}
+	
+	if adaptationRequestQueuePort == "" || archiveAdaptationRequestQueuePort == "" || transactionEventQueuePort == "" {
+		log.Fatalf("init failed: ADAPTATION_REQUEST_QUEUE_PORT, ARCHIVE_ADAPTATION_REQUEST_QUEUE_PORT or TRANSACTION_EVENT_QUEUE_PORT environment variables not set")}
+	
+	if messagebrokeruser == "" {
+		messagebrokeruser = "guest"
+	}
+	
+	if messagebrokerpassword == "" {
+		messagebrokerpassword = "guest"
+	}
+		
+	amqpUrl := url.URL{
+					Scheme: "amqp",
+					User: url.UserPassword(messagebrokeruser, messagebrokerpassword),
+					Host: fmt.Sprintf("%s:%s", adaptationRequestQueueHostname,adaptationRequestQueuePort),
+					Path: "/",
+					}
+    fmt.Println("Connecting to ", amqpUrl.Host)
 
-	conn, err := amqp.Dial(amqpURL)
-	failOnError(err, "Failed to connect to RabbitMQ")
+	conn, err := amqp.Dial(amqpUrl.String())
+	failOnError(err, fmt.Sprint("Failed to connect to %s", amqpUrl.Host))
 	defer conn.Close()
 
 	ch, err := conn.Channel()
@@ -128,7 +155,6 @@ func processMessage(d amqp.Delivery) (bool, error) {
 		Output:                   output,
 		InputMount:               inputMount,
 		OutputMount:              outputMount,
-		AmqpURL:				  amqpURL,
 		ReplyTo:                  d.ReplyTo,
 		RequestProcessingImage:   requestProcessingImage,
 		RequestProcessingTimeout: requestProcessingTimeout,

--- a/cmd/adaptation-service.go
+++ b/cmd/adaptation-service.go
@@ -122,6 +122,7 @@ func processMessage(d amqp.Delivery) (bool, error) {
 		Output:                   output,
 		InputMount:               inputMount,
 		OutputMount:              outputMount,
+		AmqpURL:				  amqpURL,
 		ReplyTo:                  d.ReplyTo,
 		RequestProcessingImage:   requestProcessingImage,
 		RequestProcessingTimeout: requestProcessingTimeout,

--- a/cmd/adaptation-service.go
+++ b/cmd/adaptation-service.go
@@ -52,6 +52,8 @@ var (
 	adaptationRequestQueuePort = os.Getenv("ADAPTATION_REQUEST_QUEUE_PORT")
 	archiveAdaptationRequestQueueHostname = os.Getenv("ARCHIVE_ADAPTATION_QUEUE_REQUEST_HOSTNAME")
 	archiveAdaptationRequestQueuePort = os.Getenv("ARCHIVE_ADAPTATION_REQUEST_QUEUE_PORT")
+	transactionEventQueueHostname = os.Getenv("TRANSACTION_EVENT_QUEUE_HOSTNAME")
+	transactionEventQueuePort = os.Getenv("TRANSACTION_EVENT_QUEUE_PORT")
 )
 
 func main() {
@@ -134,6 +136,8 @@ func processMessage(d amqp.Delivery) (bool, error) {
 		AdaptationRequestQueuePort: adaptationRequestQueuePort,
 		ArchiveAdaptationRequestQueueHostname: archiveAdaptationRequestQueueHostname,
 		ArchiveAdaptationRequestQueuePort: archiveAdaptationRequestQueuePort,
+		TransactionEventQueueHostname: transactionEventQueueHostname,
+		TransactionEventQueuePort: transactionEventQueuePort,
 	}
 
 	err = podArgs.GetClient()

--- a/cmd/adaptation-service.go
+++ b/cmd/adaptation-service.go
@@ -56,8 +56,7 @@ var (
 	transactionEventQueueHostname = os.Getenv("TRANSACTION_EVENT_QUEUE_HOSTNAME")
 	transactionEventQueuePort = os.Getenv("TRANSACTION_EVENT_QUEUE_PORT")
 	messagebrokeruser = os.Getenv("MESSAGE_BROKER_USER")
-	messagebrokerpassword = os.Getenv("MESSAGE_BROKER_PASSWORD")
-	
+	messagebrokerpassword = os.Getenv("MESSAGE_BROKER_PASSWORD")	
 )
 
 func main() {
@@ -164,6 +163,8 @@ func processMessage(d amqp.Delivery) (bool, error) {
 		ArchiveAdaptationRequestQueuePort: archiveAdaptationRequestQueuePort,
 		TransactionEventQueueHostname: transactionEventQueueHostname,
 		TransactionEventQueuePort: transactionEventQueuePort,
+		MessageBrokerUser: messagebrokeruser,
+		MessageBrokerPassword: messagebrokerpassword,
 	}
 
 	err = podArgs.GetClient()

--- a/pkg/pod.go
+++ b/pkg/pod.go
@@ -28,6 +28,8 @@ type PodArgs struct {
 	ReplyTo                  string
 	RequestProcessingImage   string
 	RequestProcessingTimeout string
+	AdaptationRequestQueueHostname string
+	AdaptationRequestQueuePort string
 }
 
 func (podArgs *PodArgs) GetClient() error {
@@ -131,6 +133,8 @@ func (pa PodArgs) GetPodObject() *core.Pod {
 						{Name: "ReplyTo", Value: pa.ReplyTo},
 						{Name: "AmqpURL", Value: pa.AmqpURL},
 						{Name: "ProcessingTimeoutDuration", Value: pa.RequestProcessingTimeout},
+						{Name: "AdaptationRequestQueueHostname", Value: pa.AdaptationRequestQueueHostname},
+						{Name: "AdaptationRequestQueuePort", Value: pa.AdaptationRequestQueuePort},
 					},
 					VolumeMounts: []core.VolumeMount{
 						{Name: "sourcedir", MountPath: pa.InputMount},

--- a/pkg/pod.go
+++ b/pkg/pod.go
@@ -32,6 +32,8 @@ type PodArgs struct {
 	AdaptationRequestQueuePort string
 	ArchiveAdaptationRequestQueueHostname string
 	ArchiveAdaptationRequestQueuePort string
+	TransactionEventQueueHostname string
+	TransactionEventQueuePort string
 }
 
 func (podArgs *PodArgs) GetClient() error {
@@ -139,6 +141,8 @@ func (pa PodArgs) GetPodObject() *core.Pod {
 						{Name: "AdaptationRequestQueuePort", Value: pa.AdaptationRequestQueuePort},
 						{Name: "ArchiveAdaptationRequestQueueHostname", Value: pa.ArchiveAdaptationRequestQueueHostname},
 						{Name: "ArchiveAdaptationRequestQueuePort", Value: pa.ArchiveAdaptationRequestQueuePort},
+						{Name: "TransactionEventQueueHostname", Value: pa.TransactionEventQueueHostname},
+						{Name: "TransactionEventQueuePort", Value: pa.TransactionEventQueuePort},
 					},
 					VolumeMounts: []core.VolumeMount{
 						{Name: "sourcedir", MountPath: pa.InputMount},

--- a/pkg/pod.go
+++ b/pkg/pod.go
@@ -24,7 +24,6 @@ type PodArgs struct {
 	Output                   string
 	InputMount               string
 	OutputMount              string
-	AmqpURL                  string
 	ReplyTo                  string
 	RequestProcessingImage   string
 	RequestProcessingTimeout string
@@ -135,7 +134,6 @@ func (pa PodArgs) GetPodObject() *core.Pod {
 						{Name: "InputPath", Value: pa.Input},
 						{Name: "OutputPath", Value: pa.Output},
 						{Name: "ReplyTo", Value: pa.ReplyTo},
-						{Name: "AmqpURL", Value: pa.AmqpURL},
 						{Name: "ProcessingTimeoutDuration", Value: pa.RequestProcessingTimeout},
 						{Name: "AdaptationRequestQueueHostname", Value: pa.AdaptationRequestQueueHostname},
 						{Name: "AdaptationRequestQueuePort", Value: pa.AdaptationRequestQueuePort},

--- a/pkg/pod.go
+++ b/pkg/pod.go
@@ -24,6 +24,7 @@ type PodArgs struct {
 	Output                   string
 	InputMount               string
 	OutputMount              string
+	AmqpURL                  string
 	ReplyTo                  string
 	RequestProcessingImage   string
 	RequestProcessingTimeout string
@@ -128,6 +129,7 @@ func (pa PodArgs) GetPodObject() *core.Pod {
 						{Name: "InputPath", Value: pa.Input},
 						{Name: "OutputPath", Value: pa.Output},
 						{Name: "ReplyTo", Value: pa.ReplyTo},
+						{Name: "AmqpURL", Value: pa.AmqpURL},
 						{Name: "ProcessingTimeoutDuration", Value: pa.RequestProcessingTimeout},
 					},
 					VolumeMounts: []core.VolumeMount{

--- a/pkg/pod.go
+++ b/pkg/pod.go
@@ -33,6 +33,8 @@ type PodArgs struct {
 	ArchiveAdaptationRequestQueuePort string
 	TransactionEventQueueHostname string
 	TransactionEventQueuePort string
+	MessageBrokerUser string
+	MessageBrokerPassword string
 }
 
 func (podArgs *PodArgs) GetClient() error {
@@ -141,6 +143,8 @@ func (pa PodArgs) GetPodObject() *core.Pod {
 						{Name: "ArchiveAdaptationRequestQueuePort", Value: pa.ArchiveAdaptationRequestQueuePort},
 						{Name: "TransactionEventQueueHostname", Value: pa.TransactionEventQueueHostname},
 						{Name: "TransactionEventQueuePort", Value: pa.TransactionEventQueuePort},
+						{Name: "MessageBrokerUser", Value: pa.MessageBrokerUser},
+						{Name: "MessageBrokerPassword", Value: pa.MessageBrokerPassword},
 					},
 					VolumeMounts: []core.VolumeMount{
 						{Name: "sourcedir", MountPath: pa.InputMount},

--- a/pkg/pod.go
+++ b/pkg/pod.go
@@ -30,6 +30,8 @@ type PodArgs struct {
 	RequestProcessingTimeout string
 	AdaptationRequestQueueHostname string
 	AdaptationRequestQueuePort string
+	ArchiveAdaptationRequestQueueHostname string
+	ArchiveAdaptationRequestQueuePort string
 }
 
 func (podArgs *PodArgs) GetClient() error {
@@ -135,6 +137,8 @@ func (pa PodArgs) GetPodObject() *core.Pod {
 						{Name: "ProcessingTimeoutDuration", Value: pa.RequestProcessingTimeout},
 						{Name: "AdaptationRequestQueueHostname", Value: pa.AdaptationRequestQueueHostname},
 						{Name: "AdaptationRequestQueuePort", Value: pa.AdaptationRequestQueuePort},
+						{Name: "ArchiveAdaptationRequestQueueHostname", Value: pa.ArchiveAdaptationRequestQueueHostname},
+						{Name: "ArchiveAdaptationRequestQueuePort", Value: pa.ArchiveAdaptationRequestQueuePort},
 					},
 					VolumeMounts: []core.VolumeMount{
 						{Name: "sourcedir", MountPath: pa.InputMount},


### PR DESCRIPTION
Updated to use the RabbitMQ hostname provided by the configuration.